### PR TITLE
[ci skip] adding user @PatrickSampaioUSP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @giovaniceotto
 * @Gui-FernandesBR
+* @PatrickSampaioUSP

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,5 +50,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - PatrickSampaioUSP
     - Gui-FernandesBR
     - giovaniceotto


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @PatrickSampaioUSP as instructed in #7.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.
